### PR TITLE
fixing autoloading

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -11,7 +11,10 @@ return PhpCsFixer\Config::create()
     ->setRules([
         '@PSR2' => true,
         '@PHPUnit60Migration:risky' => true,
-        'binary_operator_spaces' => ['align_double_arrow' => true, 'align_equals' => true],
+        'binary_operator_spaces' => [
+            'default' => 'align_single_space_minimal',
+            'operators' => ['||' => null, '&&' => null]
+        ],
         'single_quote' => true,
         'array_syntax' => ['syntax' => 'long'],
         'concat_space' => ['spacing' => 'one'],

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
         "diablomedia/zendframework1-db": "^1.0.0"
     },
     "autoload": {
-        "psr-0": {
-            "Zend_": "src/"
-        }
-    },
-    "autoload-dev": {
         "classmap": [
             "src/Zend/Auth/Adapter/DbTable.php"
         ]
+    },
+    "autoload-dev": {
+        "psr-0": {
+            "Zend_": "tests/"
+        }
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",

--- a/tests/Zend/Auth/Adapter/DbTable/BasicSqliteTest.php
+++ b/tests/Zend/Auth/Adapter/DbTable/BasicSqliteTest.php
@@ -233,7 +233,7 @@ class Zend_Auth_Adapter_DbTable_BasicSqliteTest extends PHPUnit\Framework\TestCa
         $this->_adapter->authenticate();
         $selectAfterAuth = $this->_adapter->getDbSelect();
         $whereParts      = $selectAfterAuth->getPart(Zend_Db_Select::WHERE);
-        $this->assertEquals(1, count($whereParts));
+        $this->assertCount(1, $whereParts);
         $this->assertEquals('(1 = 1)', array_pop($whereParts));
     }
 


### PR DESCRIPTION
When I fixed the autoloading in the previous PR, I had added the classmap to the wrong autoload section, so this one was still using `Zend_` namespace prefix.

Fixed that and tweaked php-cs-fixer rules slightly, and re-ran php-cs-fixer which did change a phpunit assertion (new release of php-cs-fixer added that).